### PR TITLE
Ensure that nobody can go outside cache, tmp & log folders through adapters

### DIFF
--- a/src/Adapter/BlockedLocal.php
+++ b/src/Adapter/BlockedLocal.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * @package     Phproberto\Joomla\Flysystem
+ * @subpackage  Adapter
+ *
+ * @copyright  Copyright (C) 2017 Roberto Segura López, Inc. All rights reserved.
+ * @license    See COPYING.txt
+ */
+
+namespace Phproberto\Joomla\Flysystem\Adapter;
+
+use League\Flysystem\Adapter\Local;
+use Phproberto\Joomla\Flysystem\Adapter\Traits\IsBlockedInsideRoot;
+
+/**
+ * Local adapter that prevents access to files outside root folder.
+ *
+ * @since   __DEPLOY_VERSION__
+ */
+class BlockedLocal extends Local
+{
+	use IsBlockedInsideRoot;
+}

--- a/src/Adapter/JoomlaFolder.php
+++ b/src/Adapter/JoomlaFolder.php
@@ -9,19 +9,16 @@
 
 namespace Phproberto\Joomla\Flysystem\Adapter;
 
-use League\Flysystem\Util;
-use Joomla\Registry\Registry;
-use League\Flysystem\Adapter\Local;
 use Phproberto\Joomla\Flysystem\Traits\HasEvents;
+use Phproberto\Joomla\Flysystem\Adapter\BlockedLocal;
 use Phproberto\Joomla\Flysystem\Adapter\Traits\HasParameters;
-use LogicException;
 
 /**
  * Joomla local file adapter.
  *
  * @since   __DEPLOY_VERSION__
  */
-final class JoomlaFolder extends Local
+final class JoomlaFolder extends BlockedLocal
 {
 	use HasEvents, HasParameters;
 
@@ -51,22 +48,6 @@ final class JoomlaFolder extends Local
 
 		$this->trigger('onFlysystemAfterLoadAdapter');
 		$this->trigger('onFlysystemAfterLoadJoomlaFolderAdapter', [$path, $config]);
-	}
-
-	/**
-	 * Prefix a path. Overriden to ensure that access outside root folder is forbidden.
-	 *
-	 * @param   string  $path  Path to apply prefix.
-	 *
-	 * @return  string  Prefixed path
-	 *
-	 * @throws  LogicException
-	 */
-	public function applyPathPrefix($path)
-	{
-		$path = Util::normalizeRelativePath($path);
-
-		return parent::applyPathPrefix($path);
 	}
 
 	/**

--- a/src/Adapter/Traits/IsBlockedInsideRoot.php
+++ b/src/Adapter/Traits/IsBlockedInsideRoot.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * @package     Phproberto.Joomla-Flysystem
+ * @subpackage  Adapter.Traits
+ *
+ * @copyright  Copyright (C) 2017 Roberto Segura López, Inc. All rights reserved.
+ * @license    See COPYING.txt
+ */
+
+namespace Phproberto\Joomla\Flysystem\Adapter\Traits;
+
+defined('_JEXEC') || die;
+
+use League\Flysystem\Util;
+
+/**
+ * Trait for adapters that prevent access outside root folder.
+ *
+ * @since   __DEPLOY_VERSION__
+ */
+trait IsBlockedInsideRoot
+{
+	/**
+	 * Prefix a path. Overriden to ensure that access outside root folder is forbidden.
+	 *
+	 * @param   string  $path  Path to apply prefix.
+	 *
+	 * @return  string  Prefixed path
+	 *
+	 * @throws  LogicException
+	 */
+	public function applyPathPrefix($path)
+	{
+		$path = Util::normalizeRelativePath($path);
+
+		return parent::applyPathPrefix($path);
+	}
+}

--- a/src/MountManager.php
+++ b/src/MountManager.php
@@ -10,11 +10,11 @@
 namespace Phproberto\Joomla\Flysystem;
 
 use Joomla\CMS\Factory;
-use League\Flysystem\MountManager as BaseMountManager;
-use League\Flysystem\Adapter\Local;
-use Phproberto\Joomla\Flysystem\Adapter\JoomlaFolder;
 use Phproberto\Joomla\Flysystem\JoomlaFilesystem;
 use Phproberto\Joomla\Flysystem\Traits\HasEvents;
+use Phproberto\Joomla\Flysystem\Adapter\BlockedLocal;
+use Phproberto\Joomla\Flysystem\Adapter\JoomlaFolder;
+use League\Flysystem\MountManager as BaseMountManager;
 
 /**
  * Mount manager.
@@ -51,10 +51,10 @@ final class MountManager extends BaseMountManager
 	private function coreFileSystems() : array
 	{
 		return [
-			'cache'  => new Filesystem(new Local(Factory::getConfig()->get('cache_path', JPATH_CACHE))),
-			'log'    => new Filesystem(new Local(Factory::getConfig()->get('log_path'))),
+			'cache'  => new Filesystem(new BlockedLocal(Factory::getConfig()->get('cache_path', JPATH_CACHE))),
+			'log'    => new Filesystem(new BlockedLocal(Factory::getConfig()->get('log_path'))),
 			'joomla' => new Filesystem(new JoomlaFolder),
-			'tmp'    => new Filesystem(new Local(Factory::getConfig()->get('tmp_path')))
+			'tmp'    => new Filesystem(new BlockedLocal(Factory::getConfig()->get('tmp_path')))
 		];
 	}
 }

--- a/tests/Unit/Adapter/JoomlaFolderTest.php
+++ b/tests/Unit/Adapter/JoomlaFolderTest.php
@@ -9,12 +9,13 @@
 
 namespace Phproberto\Joomla\Flysystem\Tests\Unit\Adapter;
 
+use LogicException;
 use Joomla\CMS\Factory;
 use League\Flysystem\AdapterInterface;
 use Joomla\CMS\Application\CMSApplication;
 use Phproberto\Joomla\Flysystem\Adapter\JoomlaFolder;
 use Phproberto\Joomla\Flysystem\Tests\Unit\TestWithEvents;
-use LogicException;
+use Phproberto\Joomla\Flysystem\Tests\Unit\Adapter\Traits\IsBlockedInsideRoot;
 
 /**
  * JoomlaFolder adapter tests.
@@ -23,6 +24,8 @@ use LogicException;
  */
 class JoomlaFolderTest extends TestWithEvents
 {
+	use IsBlockedInsideRoot;
+
 	/**
 	 * Tested adapter.
 	 *
@@ -108,20 +111,6 @@ class JoomlaFolderTest extends TestWithEvents
 	}
 
 	/**
-	 * @test
-	 *
-	 * @dataProvider insecurePaths
-	 *
-	 * @return void
-	 *
-	 * @expectedException  LogicException
-	 */
-	public function throwsExceptonOnInsecurePaths($path)
-	{
-		$this->adapter->has($path);
-	}
-
-	/**
 	 * Triggered before adapter has been loaded.
 	 *
 	 * @param   AdapterInterface  $adapter  Adapter being instatiated
@@ -181,20 +170,4 @@ class JoomlaFolderTest extends TestWithEvents
 
 		$adapter->setParam('onFlysystemAfterLoadJoomlaFolderAdapter', true);
 	}
-
-	/**
-	 * List of insecure paths to prevent unauthorised access.
-	 *
-	 * @return  array
-	 */
-	public function insecurePaths()
-	{
-		return [
-			['../index.php'],
-			['./../index.php'],
-			['./jui/../../index.php'],
-			['..']
-		];
-	}
-
 }

--- a/tests/Unit/Adapter/Traits/IsBlockedInsideRoot.php
+++ b/tests/Unit/Adapter/Traits/IsBlockedInsideRoot.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * @package     Phproberto.Joomla-Flysystem
+ * @subpackage  Tests.Unit.Adapter.Traits
+ *
+ * @copyright  Copyright (C) 2017 Roberto Segura López, Inc. All rights reserved.
+ * @license    See COPYING.txt
+ */
+
+namespace Phproberto\Joomla\Flysystem\Tests\Unit\Adapter\Traits;
+
+defined('_JEXEC') || die;
+
+use LogicException;
+
+/**
+ * Trait easily add tests that prevent access outside root folder.
+ *
+ * @since   __DEPLOY_VERSION__
+ */
+trait IsBlockedInsideRoot
+{
+	/**
+	 * @test
+	 *
+	 * @param   string  $path  Insecure path to test
+	 *
+	 * @return  void
+	 *
+	 * @dataProvider insecurePaths
+	 *
+	 * @expectedException  LogicException
+	 */
+	public function throwsExceptionOnInsecurePaths($path)
+	{
+		$this->adapter->has($path);
+	}
+
+	/**
+	 * Provider of insecure paths to test.
+	 *
+	 * @return  array
+	 */
+	public function insecurePaths()
+	{
+		return [
+			['../index.php'],
+			['./../index.php'],
+			['./jui/../../index.php'],
+			['..']
+		];
+	}
+}


### PR DESCRIPTION
After fixing JoomlaFolder adapter to prevent access to files outside joomla folder I wanted to ensure that local adapters used for tmp, log & cache folders are blocked into their own root folders to prevent access outside those folders.

This creates a new `BlockedLocal` adapter that restricts access to files outside root folder.